### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/vijayocta0992/741507ca-f1c4-49fb-8052-2e04b7e8658e/1eff620f-e6b1-46cb-84dc-58392800e13d/_apis/work/boardbadge/5851f781-c37c-4bcc-9e10-37b28c6ce257)](https://dev.azure.com/vijayocta0992/741507ca-f1c4-49fb-8052-2e04b7e8658e/_boards/board/t/1eff620f-e6b1-46cb-84dc-58392800e13d/Microsoft.RequirementCategory)
 # boardstest


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/vijayocta0992/741507ca-f1c4-49fb-8052-2e04b7e8658e/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.